### PR TITLE
Fixed remove not needed variable from global scope

### DIFF
--- a/resources/js/cbpAnimatedHeader.js
+++ b/resources/js/cbpAnimatedHeader.js
@@ -8,7 +8,7 @@
  * Copyright 2013, Codrops
  * http://www.codrops.com
  */
-var cbpAnimatedHeader = (function() {
++(function(document, window, undefined) {
 
 	var docElem = document.documentElement,
 		header = document.querySelector( '.navbar-fixed-top' ),
@@ -41,4 +41,4 @@ var cbpAnimatedHeader = (function() {
 
 	init();
 
-})();
+})(document, window);


### PR DESCRIPTION
Unnamed function is much better way to call JS code then named, because global vars in browser is not good.
Some people sad that it is nearly evil.

`+` we need if somebody in code behind forget to add semicolon.